### PR TITLE
Feature/td 5063 update documentation to replace nhs.uk frontend with nhs.uk frontend tel

### DIFF
--- a/app/index.njk
+++ b/app/index.njk
@@ -10,7 +10,7 @@
   {{ super() }}
 
   {{ hero({
-    "heading": "NHS.UK frontend",
+    "heading": "NHS.UK frontend TEL",
     "text": "Code you need to start building accessible user interfaces for NHS websites and services."
   }) }}
 {% endblock %}
@@ -49,10 +49,5 @@
 
   <hr class="nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-6">
 
-  <div class="nhsuk-u-reading-width">
-
-    <p class="nhsuk-u-margin-bottom-0">Visit the <a href="https://service-manual.nhs.uk/">NHS digital service manual</a> for guidance and examples.</p>
-
-  </div>
 
 {% endblock %}

--- a/app/pages/about.njk
+++ b/app/pages/about.njk
@@ -12,7 +12,7 @@
     items: [
       {
         href: "../",
-        text: "NHS.UK frontend"
+        text: "NHS.UK frontend TEL"
       }
     ]
   }) }}
@@ -25,11 +25,11 @@
   <div class="nhsuk-u-reading-width">
 
     <h2>Contributing</h2>
-    <p>Please see our <a href="https://github.com/nhsuk/nhsuk-frontend/blob/master/CONTRIBUTING.md">contributing guidelines</a> on how to set up the project locally and contribute changes to NHS.UK frontend.</p>
+    <p>Please see our <a href="https://github.com/TechnologyEnhancedLearning/nhsuk-frontend-tel/blob/master/CONTRIBUTING.md">contributing guidelines</a> on how to set up the project locally and contribute changes to NHS.UK frontend TEL.</p>
 
     <h2>Get in touch</h2>
-    <p>NHS.UK frontend is actively maintained by a team at NHS England, you can <a href="mailto:service-manual@nhs.net">email us</a> or get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS digital service manual Slack workspace</a>.</p>
-  
+    <p>NHS.UK frontend TEL is actively maintained by a team at NHS England, you can <a href="mailto:support@learninghub.nhs.uk">email us</a>.</p>
+
   </div>
 
 {% endblock %}

--- a/app/pages/examples.njk
+++ b/app/pages/examples.njk
@@ -12,7 +12,7 @@
     items: [
       {
         href: "../",
-        text: "NHS.UK frontend"
+        text: "NHS.UK frontend TEL"
       }
     ]
   }) }}
@@ -131,7 +131,7 @@
     <li><a href="../components/warning-callout/index.html">Warning callout</a></li>
     <li><a href="../components/warning-callout/custom-heading.html">Warning callout with custom heading</a></li>
   </ul>
-  
+
 {% endblock %}
 
 {% block footer %}
@@ -140,7 +140,7 @@
     "links": [
       {
         "URL": baseUrl,
-        "label": "NHS.UK frontend"
+        "label": "NHS.UK frontend TEL"
       },
       {
         "URL": baseUrl + "pages/install.html",
@@ -155,7 +155,7 @@
         "label": "About"
       },
       {
-        "URL": "https://github.com/nhsuk/nhsuk-frontend",
+        "URL": "https://github.com/TechnologyEnhancedLearning/nhsuk-frontend-tel",
         "label": "GitHub"
       }
     ]

--- a/docs/contributing/application-architecture.md
+++ b/docs/contributing/application-architecture.md
@@ -10,7 +10,7 @@ GitHub specific files, such templates for pull requests and issues.
 
 `app/`
 
-Nunjuck (HTML) files for the component example pages that you see at http://localhost:3000 when running the application locally and on https://nhsuk.github.io/nhsuk-frontend
+Nunjuck (HTML) files for the component example pages that you see at http://localhost:3000 when running the application locally.
 
 `dist/` (Automatically generated)
 
@@ -26,7 +26,7 @@ Node package manager modules for third party dependencies. This folder is automa
 
 `packages/`
 
-NHS.UK frontend individual components files, such as all the stylesheet (scss) files, HTML templates (nunjucks), READMEs and assets.
+NHS.UK frontend TEL individual components files, such as all the stylesheet (scss) files, HTML templates (nunjucks), READMEs and assets.
 
 `tasks/`
 

--- a/docs/contributing/automated-testing.md
+++ b/docs/contributing/automated-testing.md
@@ -10,7 +10,7 @@ For full documentation on the BackstopJS framework, read the [BackstopJS documen
 
 ### Tests configuration
 
-BackstopJS tests configuration and files can be found within the `backstop` folder in the [tests directory](https://github.com/nhsuk/nhsuk-frontend/tree/master/tests).
+BackstopJS tests configuration and files can be found within the `backstop` folder in the [tests directory](https://github.com/TechnologyEnhancedLearning/nhsuk-frontend-tel/tree/main/tests).
 
 `backstop.js` contains all the test configuration and tests scenarios.
 

--- a/docs/contributing/browser-support.md
+++ b/docs/contributing/browser-support.md
@@ -1,10 +1,9 @@
 # Browser support
 
-NHS.UK frontend browser support is shown in the table below.
+NHS.UK frontend TEL browser support is shown in the table below.
 
 | Operating system | Browser                            | Support   |
 | ---------------- | ---------------------------------- | --------- |
-| Windows          | Internet Explorer 11               | compliant |
 | Windows          | Edge (latest versions)             | compliant |
 | Windows          | Google Chrome (latest versions)    | compliant |
 | Windows          | Mozilla Firefox (latest versions)  | compliant |
@@ -24,7 +23,7 @@ We no longer support older versions of Internet Explorer. This is due to the ver
 
 # Assistive technology support
 
-We test the NHS.UK frontend with the following assistive technology:
+We test the NHS.UK frontend TEL with the following assistive technology:
 
 | Software                                                                                              | Type                                   | Browser                                       |
 | ----------------------------------------------------------------------------------------------------- | -------------------------------------- | --------------------------------------------- |

--- a/docs/contributing/coding-standards.md
+++ b/docs/contributing/coding-standards.md
@@ -50,7 +50,7 @@ use a different prefix, for example `.app-` or the initials of your department.
 
 ### Block Element Modifier (BEM)
 
-NHS.UK frontend uses the Block Element Modifier (BEM) methodology when naming
+NHS.UK frontend TEL uses the Block Element Modifier (BEM) methodology when naming
 CSS classes. This is designed to help developers understand how the different
 classes relate to each other.
 
@@ -228,7 +228,7 @@ We're still writing our JavaScript style guide, as we're only just figuring it o
 
 ## Nunjucks
 
-We have chosen as Nunjucks as the templating language for NHS.UK frontend components. We expose those templates as reusable chunks of code: macros. Developers import macros into their application, call them as per documentation and provide data to its arguments.
+We have chosen as Nunjucks as the templating language for NHS.UK frontend TEL components. We expose those templates as reusable chunks of code: macros. Developers import macros into their application, call them as per documentation and provide data to its arguments.
 
 To provide a level of consistency for developers we have standardised argument names, their expected input, use and placement. There are expectations, and if so they are documented accordingly.
 
@@ -287,7 +287,7 @@ Care card emergency (red and black) example:
 
 ## Components
 
-You can find NHS.UK frontend components in `packages/components`.
+You can find NHS.UK frontend TEL components in `packages/components`.
 
 Components must use the `.nhsuk-` namespace.
 

--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-To run NHS.UK frontend locally you'll need to:
+To run NHS.UK frontend TEL locally you'll need to:
 
 - [set up git](https://help.github.com/articles/set-up-git/)
 - [install Node.js](https://nodejs.org/en/)
@@ -18,16 +18,16 @@ To run NHS.UK frontend locally you'll need to:
 
 ## 2. Clone the repository
 
-You can clone the repository directly if you're a member of the [NHS.UK GitHub organisation](https://github.com/nhsuk/)
+You can clone the repository directly if you're a member of the [NHS.UK TEL GitHub organisation](https://github.com/TechnologyEnhancedLearning/)
 
 ```
-git clone git@github.com:nhsuk/nhsuk-frontend.git nhsuk-frontend
+git clone git@github.com:TechnologyEnhancedLearning/nhsuk-frontend-tel.git nhsuk-frontend-tel
 ```
 
 Otherwise you'll have to clone your own fork
 
 ```
-git clone https://github.com/[Username]/nhsuk-frontend.git nhsuk-frontend
+git clone https://github.com/[Username]/nhsuk-frontend-tel.git nhsuk-frontend-tel
 ```
 
 > Replace '[Username]' in the git clone command above with your own GitHub username.
@@ -39,7 +39,7 @@ We use [node package manager (npm)](https://docs.npmjs.com/getting-started/what-
 Whilst in the project directory you will need to install the dependencies listed in `package.json`
 
 ```
-cd nhsuk-frontend
+cd nhsuk-frontend-tel
 ```
 
 ```

--- a/docs/installation/installing-compiled.md
+++ b/docs/installation/installing-compiled.md
@@ -1,6 +1,6 @@
 # Installing using compiled files
 
-When installing NHS.UK frontend using compiled files, you are using compiled and minified versions of the stylesheet and JavaScript.
+When installing NHS.UK frontend TEL using compiled files, you are using compiled and minified versions of the stylesheet and JavaScript.
 
 This means that you will not be able to:
 
@@ -14,7 +14,7 @@ If you require any of this functionality, you should [install using npm](/docs/i
 
 1. Download the compiled files
 
-   [Download the latest CSS, JavaScript and assets from GitHub (zip file)](https://github.com/nhsuk/nhsuk-frontend/releases)
+   [Download the latest CSS, JavaScript and assets from GitHub (zip file)](https://github.com/nhsuk/nhsuk-frontend-tel/releases)
 
 2. Include resources
 
@@ -52,6 +52,4 @@ If you require any of this functionality, you should [install using npm](/docs/i
    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
    ```
 
-4. Create pages using NHS.UK frontend
-
-   You can now create pages using the [Design system on the NHS digital service manual](https://service-manual.nhs.uk/design-system).
+4. Create pages using NHS.UK frontend TEL

--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-To use NHS.UK frontend in your projects with npm you must:
+To use NHS.UK frontend TEL in your projects with npm you must:
 
 1. Have [Node.js](https://nodejs.org/en/) installed. We recommend using the [long-term support (LTS)](https://nodejs.org/en/download/) version of Nodejs, which also includes [npm](https://www.npmjs.com/).
 
@@ -18,15 +18,15 @@ To use NHS.UK frontend in your projects with npm you must:
 
 ## Installation
 
-Install the NHS.UK frontend package into your project:
+Install the NHS.UK frontend TEL package into your project:
 
 ```
-npm install nhsuk-frontend --save
+npm install nhsuk-frontend-tel --save
 ```
 
 ## Configuration
 
-You will need to import a couple of things into your project before you can start using NHS.UK frontend:
+You will need to import a couple of things into your project before you can start using NHS.UK frontend TEL:
 
 - [Importing styles](#importing-styles)
 - [Importing JavaScript](#importing-javascript)
@@ -36,27 +36,27 @@ You will need to import a couple of things into your project before you can star
 
 To build the stylesheet you will need a pipeline set up to compile [Sass](https://sass-lang.com/) files to CSS. We recommend using [gulp](https://gulpjs.com/) and [gulp-sass](https://www.npmjs.com/package/gulp-sass) however you can use any tools that you are familiar with.
 
-You need to import the NHS.UK frontend styles into the main Sass file in your project. You should place the below code before your own Sass rules (or Sass imports).
+You need to import the NHS.UK frontend TEL styles into the main Sass file in your project. You should place the below code before your own Sass rules (or Sass imports).
 
 ```SCSS
-@import 'node_modules/nhsuk-frontend/packages/nhsuk';
+@import 'node_modules/nhsuk-frontend-tel/packages/nhsuk';
 ```
 
 Alternatively you can import each of the individual components separately, meaning you can import just the components that you are using.
 
 ```SCSS
 // Core (required)
-@import 'node_modules/nhsuk-frontend/packages/core/all';
+@import 'node_modules/nhsuk-frontend-tel/packages/core/all';
 
 // Individual component (optional)
-@import 'node_modules/nhsuk-frontend/packages/components/action-link/action-link';
+@import 'node_modules/nhsuk-frontend-tel/packages/components/action-link/action-link';
 ```
 
 ## Importing JavaScript
 
 Some of our components require JavaScript to function properly, others need JavaScript to improve the usability and accessibility.
 
-You should include NHS.UK frontend JavaScript in your project to ensure that all users can use it successfully.
+You should include NHS.UK frontend TEL JavaScript in your project to ensure that all users can use it successfully.
 
 Add the following JavaScript to the top of the `<body>` section of your page template:
 
@@ -66,7 +66,7 @@ document.body.className = ((document.body.className) ? document.body.className +
 
 ### Option 1: Include compiled JavaScript
 
-Include the `node_modules/nhsuk-frontend/dist/nhsuk.min.js` script in the `<head>` of your page using the `defer` attribute.
+Include the `node_modules/nhsuk-frontend-tel/dist/nhsuk.min.js` script in the `<head>` of your page using the `defer` attribute.
 
 > The defer attribute is used for performance benefits as the browser loads the JavaScript file as soon as possible, due to it being in the `<head>`, but will not run until after the page has loaded.
 
@@ -78,7 +78,7 @@ You might wish to copy the file into your project or reference it straight from 
 ```
 
 ```html
-    <script src="node_modules/nhsuk-frontend/dist/nhsuk.min.js" defer></script>
+    <script src="node_modules/nhsuk-frontend-tel/dist/nhsuk.min.js" defer></script>
   </head>
 ```
 
@@ -96,7 +96,7 @@ import Radios from './components/radios/radios';
 import SkipLink from './components/skip-link/skip-link';
 
 // Polyfills
-import '../node_modules/nhsuk-frontend/packages/polyfills';
+import '../node_modules/nhsuk-frontend-tel/packages/polyfills';
 
 // Initialize components
 document.addEventListener('DOMContentLoaded', () => {
@@ -111,7 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 ## Importing assets (optional)
 
-If you want to import assets such as the NHS logo, favicons and SVG icons, you might wish to copy the files into your project folders from the `node_modules/nhsuk-frontend/assets/` directory or you can reference them straight from the `node_modules` folder.
+If you want to import assets such as the NHS logo, favicons and SVG icons, you might wish to copy the files into your project folders from the `node_modules/nhsuk-frontend-tel/assets/` directory or you can reference them straight from the `node_modules` folder.
 
 ```html
 <link rel="shortcut icon" href="path-to-assets/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
## Description
Updated references to NHS.UK frontend to NHS.UK frontend TEL
Removed links to service manual and slack
## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
